### PR TITLE
优化昼夜模式颜色过渡效果

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -109,19 +109,26 @@ body {
   font-size: 0.75rem;
 }
 
+/* 添加过渡效果 */
+
 * {
     transition-property: color, background-color;
     /* 设置过渡的属性 */
-    transition-duration: 0.5s;
+    transition-duration: 0.3s;
     /* 设置过渡的时间 */
-    transition-timing-function: cubic-bezier(0.01, 0.34, 0.9, 1.14);
+    transition-timing-function: cubic-bezier(0.07, 0.51, 0.7, 1);
     /* 设置过渡的缓动函数 */
 }
 
-/* 屏蔽过渡效果 */
-p,
-h1,
-h2,
-hr {
-    transition: none !important;
+/*取消导航栏的背景色和阴影*/
+/*因为左右侧导航栏(目录)的开头背景色是独立的,这里特殊处理一下*/
+@media screen and (min-width: 76.25em) {
+
+    .md-nav--lifted>.md-nav__list>.md-nav__item--active>.md-nav__link,
+    .md-nav--secondary .md-nav__title {
+        background: none;
+        box-shadow: none;
+    }
 }
+
+/*上面是过渡效果*/


### PR DESCRIPTION
预览地址  https://hello-ctf.vercel.app/ （科学上网）

左右侧的目录，最上边，背景貌似是独立于大背景的，这就导致切换渐变的时候，这两个地方会看起来：闪一下

这几天一直在想怎么让这个背景和大背景统一起来，试了很多方法都没成功

结果今晚突然想到直接把这个background设置为none了，居然解决问题了

然后改了一下渐变函数，让小字的渐变延时没那么长

主要解决的是这两个地方的背景
![image](https://github.com/ProbiusOfficial/Hello-CTF/assets/109416673/013ffc37-7d75-40e8-a4f6-05f71dda2d68)