### PR TITLE
fix: 找不到gcc导致Docker编译失败

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.9.0-alpine
 
 ENV PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
 RUN pip install --upgrade pip
+RUN apk add --no-cache build-base
 
 WORKDIR /Hello-CTF
 COPY mkdocs.yml ./mkdocs.yml


### PR DESCRIPTION
报错日志

```
71.70 Building wheels for collected packages: paginate, regex, watchdog
71.70   Building wheel for paginate (setup.py): started
71.94   Building wheel for paginate (setup.py): finished with status 'done'
71.94   Created wheel for paginate: filename=paginate-0.5.6-py3-none-any.whl size=12891 sha256=917e378a3f552834f1c38c308e876bc6be7b01d06fe75f8ea6556d1cac795f0c    
71.94   Stored in directory: /root/.cache/pip/wheels/ef/fe/80/f4d432480096de74f02c32495bab5bff137b26c8ca88321b3a
71.95   Building wheel for regex (pyproject.toml): started
72.11   Building wheel for regex (pyproject.toml): finished with status 'error'
72.12   error: subprocess-exited-with-error
72.12
72.12   × Building wheel for regex (pyproject.toml) did not run successfully.
72.12   │ exit code: 1
72.12   ╰─> [16 lines of output]
72.12       running bdist_wheel
72.12       running build
72.12       running build_py
72.12       creating build
72.12       creating build/lib.linux-x86_64-cpython-39
72.12       creating build/lib.linux-x86_64-cpython-39/regex
72.12       copying regex_3/__init__.py -> build/lib.linux-x86_64-cpython-39/regex
72.12       copying regex_3/regex.py -> build/lib.linux-x86_64-cpython-39/regex
72.12       copying regex_3/_regex_core.py -> build/lib.linux-x86_64-cpython-39/regex
72.12       copying regex_3/test_regex.py -> build/lib.linux-x86_64-cpython-39/regex
72.12       running build_ext
72.12       building 'regex._regex' extension
72.12       creating build/temp.linux-x86_64-cpython-39
72.12       creating build/temp.linux-x86_64-cpython-39/regex_3
72.12       gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -I/usr/local/include/python3.9 -c regex_3/_regex.c -o build/temp.linux-x86_64-cpython-39/regex_3/_regex.o
72.12       error: command 'gcc' failed: No such file or directory
72.12       [end of output]
72.12
72.12   note: This error originates from a subprocess, and is likely not a problem with pip.
72.12   ERROR: Failed building wheel for regex
72.12   Building wheel for watchdog (pyproject.toml): started
72.33   Building wheel for watchdog (pyproject.toml): finished with status 'done'
72.33   Created wheel for watchdog: filename=watchdog-4.0.1-py3-none-any.whl size=82996 sha256=62a4647514df346d0e299cd34c2d9354f6a6027f07cddc483ff38ca128050bd8    
72.33   Stored in directory: /root/.cache/pip/wheels/24/a0/b8/eb615c3cfe372f1731a2eddf45c3db5e6ef2d3aaa0282ab918
72.34 Successfully built paginate watchdog
72.34 Failed to build regex
72.34 ERROR: Could not build wheels for regex, which is required to install pyproject.toml-based projects
------
Dockerfile:12
--------------------
  10 |     COPY requirements.txt ./requirements.txt
  11 |
  12 | >>> RUN pip install -r requirements.txt
  13 |
  14 |     RUN mkdocs build
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install -r requirements.txt" did not complete successfully: exit code: 1
```