### PR TITLE
Update MLP.md

### DIFF
--- a/docs/HC_AI/MLP.md
+++ b/docs/HC_AI/MLP.md
@@ -363,9 +363,9 @@ class MLP(nn.Module):
         )
     #forward函数定义该神经如何处理数据，也就是数据如何在网络中前进
     def forward(self, x):
-        x = torch.flatten(-1)		#首先将x展平为一维数组
+        x = torch.flatten(x, start_dim=1)		#首先将x展平为一维数组
         x = self.classifier(x)		#将x放入上面定义的函数中
-        x = nn.Softmax(x, dim=1)           #将x进行归一化处理，转换为概率分布
+        x = nn.functional.softmax(x, dim=1)           #将x进行归一化处理，转换为概率分布
         return x
    
      
@@ -403,7 +403,7 @@ def train(model):
 
             #每到一定阶段就打印目前训练进度以及相关信息，下面代码是print(f"")格式化输出，看不懂就把代码跑起来一看就懂
             if index % 100 == 0:
-                print(f'Train Epoch: {epoch} [{index * len(data)}/{len(train_loader.dataset)} ({(100. * index / len(train_loader)):.0f}%)]\tLoss: {loss.data[0]:.6f}')
+                print(f'Train Epoch: {epoch} [{index * len(data)}/{len(train_loader.dataset)} ({(100. * index / len(train_loader)):.0f}%)]\tLoss: {loss.item():.6f}')
 
 
     model.eval()		#训练结束（不启用 Batch Normalization 和 Dropout）
@@ -424,11 +424,11 @@ def test(model):
     correct = 0		#正确
     
     #和训练一样，使用enumerate对test_loader进行迭代
-    for index, (data, target) in enumerate对(test_loader):
+    for index, (data, target) in enumerate(test_loader):
         data, target = data.to(DEVICE), target.to(DEVICE)
 
         pred = model(data)
-        correct += (torch.argmax(pred) == target).sum()		#检测预测是否正确，因为是批处理，所以求和
+        correct += (torch.argmax(pred,dim=1) == target).sum()		#检测预测是否正确，因为是批处理，所以求和
         total += pred.size(0)
 
     print("Correct : ",correct,'/',total,sep='')


### PR DESCRIPTION
主要对最后部分的代码进行了修改：
28：torch.flatten 的参数问题： torch.flatten 的正确用法是torch.flatten(input, start_dim=0, end_dim=-1)，仅用‘-1’作为参数会报错，这里修改为x = torch.flatten(x, start_dim=1)。 30：nn.Softmax 是一个类，而不是一个函数，这里修改为nn.functional.softmax()。 68：在较新的 PyTorch 版本中，loss.data[0] 这种访问方式已经被弃用，使用 loss.item() 来获取损失值。 92：torch.argmax(pred) 返回的是整个张量中最大值的索引，而不是每个样本的最大值索引，应该使用 torch.argmax(pred, dim=1) 来获取每个样本的预测类别。