### PR TITLE
doc: 修复对于PHP中关于MD5和SHA1匹配绕过payload的markdown渲染问题

### DIFF
--- a/docs/hc-tags/web/PHP_features.md
+++ b/docs/hc-tags/web/PHP_features.md
@@ -305,7 +305,7 @@ PHP在处理哈希字符串时，它把每一个以“0E”开头的哈希值都
 
 这一点在 md5() / sha1() 都适用，以下是可用的payload：
 
-```md5 0e payload
+```
 # md5 0e payload
 QNKCDZO
 240610708
@@ -314,7 +314,7 @@ s155964671a
 s214587387a
 ```
 
-```sha1 0e payload
+```
 # sha1 0e payload
 aaroZmOk
 aaK1STfY


### PR DESCRIPTION
https://hello-ctf.com/hc-tags/web/PHP_features/#0e-bypass

<img width="1125" height="690" alt="image" src="https://github.com/user-attachments/assets/da7a7a9f-9097-4b0b-b894-23cb687959e2" />

此处的渲染时好像不能正确解析 \`\`\`md5 0e payload 。大概因为这个markdown渲染器的\`\`\`后面必须跟支持的语言（？）
nvm，这个PR直接把md5 0e payload删了，可以恢复正常。